### PR TITLE
Change paths in readme and package.json to brickify organization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## Installation
 
-`$ git clone https://github.com/stuikomma/lowfab.git`
+`$ git clone https://github.com/brickify/brickify.git`
 
-`$ cd lowfab`
+`$ cd brickify`
 
 Install dependencies: `$ npm install`
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lego"
   ],
   "homepage": "http://brickify.it",
-  "bugs": "http://github.com/stuikomma/lowfab/issues",
+  "bugs": "http://github.com/brickify/brickify/issues",
   "dependencies": {
     "PEP": "brickify/PEP#0.3.1",
     "array.prototype.find": "^1.0.0",
@@ -87,7 +87,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "http://github.com/stuikomma/lowfab.git"
+    "url": "http://github.com/brickify/brickify.git"
   },
   "author": "HPI HCI-Bachelorprojekt 2014",
   "contributors": [


### PR DESCRIPTION
Closes #490 as soon as @stuikomma moved the project to https://github.com/brickify/brickify