### PR TITLE
increase timeout so that the test does not fail

### DIFF
--- a/test/core.coffee
+++ b/test/core.coffee
@@ -20,6 +20,7 @@ describe 'Brickify', ->
 
 	describe 'Server', ->
 		it 'should host the brickify website', (done) ->
+			@timeout(5000)
 			request = http.request(
 				{method: 'HEAD', host: 'localhost', port: 3001},
 				(response) ->


### PR DESCRIPTION
it typically takes around 3 seconds to start brickify on my machine atm, default timeout is 2 seconds