### PR TITLE
fix voxelizer

### DIFF
--- a/src/plugins/newBrickator/pipeline/HullVoxelizer.coffee
+++ b/src/plugins/newBrickator/pipeline/HullVoxelizer.coffee
@@ -192,7 +192,7 @@ module.exports = class Voxelizer
 				aIsInVoxel = roundA.x is x and roundA.y is y and roundA.z is z
 				bIsInVoxel = roundB.x is x and roundB.y is y and roundB.z is z
 
-				if aIsInVoxel && bIsInVoxel
+				if aIsInVoxel and bIsInVoxel
 					return Math.max a.z, b.z
 				if aIsInVoxel && a.z > b.z
 					return a.z

--- a/src/plugins/newBrickator/pipeline/HullVoxelizer.coffee
+++ b/src/plugins/newBrickator/pipeline/HullVoxelizer.coffee
@@ -189,14 +189,8 @@ module.exports = class Voxelizer
 				roundA = @_roundVoxelSpaceToVoxel a
 				roundB = @_roundVoxelSpaceToVoxel b
 
-				if roundA.x is x and roundA.y is y and roundA.z is z
-					aIsInVoxel = true
-				else
-					aIsInVoxel = false
-				if roundB.x is x and roundB.y is y and roundB.z is z
-					bIsInVoxel = true
-				else
-					bIsInVoxel = false
+				aIsInVoxel = roundA.x is x and roundA.y is y and roundA.z is z
+				bIsInVoxel = roundB.x is x and roundB.y is y and roundB.z is z
 
 				if aIsInVoxel && bIsInVoxel
 					return Math.max a.z, b.z

--- a/src/plugins/newBrickator/pipeline/HullVoxelizer.coffee
+++ b/src/plugins/newBrickator/pipeline/HullVoxelizer.coffee
@@ -251,8 +251,8 @@ module.exports = class Voxelizer
 				grid[x][y] = [] unless grid[x][y]
 				oldValue = grid[x][y][z]
 				if oldValue
-					if oldValue.dir is 0 or (zValue > oldValue.z and direction isnt 0) or
-					(Math.abs(zValue - oldValue.z) < floatDelta and direction is 1)
+					if oldValue.dir is 0 or (direction isnt 0 and zValue > oldValue.z) or
+					(direction is 1 and Math.abs(zValue - oldValue.z) < floatDelta)
 						oldValue.z = zValue
 						oldValue.dir = direction
 				else

--- a/src/plugins/newBrickator/pipeline/HullVoxelizer.coffee
+++ b/src/plugins/newBrickator/pipeline/HullVoxelizer.coffee
@@ -203,31 +203,31 @@ module.exports = class Voxelizer
 
 				if d.x isnt 0
 					k = (x - 0.5 - a.x) / d.x
-					if k >= 0 and k <= 1
+					if k >= 0
 						return a.z + k * d.z
 
 					k = (x + 0.5 - a.x) / d.x
-					if k >= 0 and k <= 1
+					if k >= 0
 						return a.z + k * d.z
 
 				if d.y isnt 0
 					k = (y - 0.5 - a.y) / d.y
-					if k >= 0 and k <= 1
+					if k >= 0
 						return a.z + k * d.z
 
 					k = (y + 0.5 - a.y) / d.y
-					if k >= 0 and k <= 1
+					if k >= 0
 						return a.z + k * d.z
 
 				if d.z isnt 0
 					minZ = z - 0.5
 					k = (minZ - a.z) / d.z
-					if k >= 0 and k <= 1
+					if k >= 0
 						return minZ
 
 					maxZ = z + 0.5
 					k = (maxZ - a.z) / d.z
-					if k >= 0 and k <= 1
+					if k >= 0
 						return maxZ
 
 				return z

--- a/src/plugins/newBrickator/pipeline/HullVoxelizer.coffee
+++ b/src/plugins/newBrickator/pipeline/HullVoxelizer.coffee
@@ -203,31 +203,31 @@ module.exports = class Voxelizer
 
 				if d.x isnt 0
 					k = (x - 0.5 - a.x) / d.x
-					if k >= 0 and k <= 1
+					if 0 <= k <= 1
 						return a.z + k * d.z
 
 					k = (x + 0.5 - a.x) / d.x
-					if k >= 0 and k <= 1
+					if 0 <= k <= 1
 						return a.z + k * d.z
 
 				if d.y isnt 0
 					k = (y - 0.5 - a.y) / d.y
-					if k >= 0 and k <= 1
+					if 0 <= k <= 1
 						return a.z + k * d.z
 
 					k = (y + 0.5 - a.y) / d.y
-					if k >= 0 and k <= 1
+					if 0 <= k <= 1
 						return a.z + k * d.z
 
 				if d.z isnt 0
 					minZ = z - 0.5
 					k = (minZ - a.z) / d.z
-					if k >= 0 and k <= 1
+					if 0 <= k <= 1
 						return minZ
 
 					maxZ = z + 0.5
 					k = (maxZ - a.z) / d.z
-					if k >= 0 and k <= 1
+					if 0 <= k <= 1
 						return maxZ
 
 				return z

--- a/src/plugins/newBrickator/pipeline/HullVoxelizer.coffee
+++ b/src/plugins/newBrickator/pipeline/HullVoxelizer.coffee
@@ -19,7 +19,7 @@ module.exports = class Voxelizer
 
 		voxelSpaceModel = @_getOptimizedVoxelSpaceModel optimizedModel, options
 
-		callback = (message) =>
+		progressAndFinishedCallback = (message) =>
 			if message.state is 'progress'
 				progressCallback message.progress
 			else # if state is 'finished'
@@ -31,7 +31,7 @@ module.exports = class Voxelizer
 			lineStepSize
 			floatDelta
 			voxelRoundingThreshold
-			callback
+			progressAndFinishedCallback
 		)
 
 		return new Promise (@resolve, reject) => return
@@ -172,9 +172,9 @@ module.exports = class Voxelizer
 					unless @_isOnVoxelBorder currentGridPosition
 						oldVoxel = currentVoxel
 						currentVoxel = @_roundVoxelSpaceToVoxel currentGridPosition
-						if (oldVoxel.x != currentVoxel.x) or
-						(oldVoxel.y != currentVoxel.y) or
-						(oldVoxel.z != currentVoxel.z)
+						if (oldVoxel.x isnt currentVoxel.x) or
+						(oldVoxel.y isnt currentVoxel.y) or
+						(oldVoxel.z isnt currentVoxel.z)
 							z = @_getGreatestZInVoxel a, b, currentVoxel
 							@_setVoxel currentVoxel, z, direction, grid
 					currentGridPosition.x += dx
@@ -203,9 +203,9 @@ module.exports = class Voxelizer
 
 				if aIsInVoxel and bIsInVoxel
 					return Math.max a.z, b.z
-				if aIsInVoxel && a.z > b.z
+				if aIsInVoxel and a.z > b.z
 					return a.z
-				if bIsInVoxel && b.z > a.z
+				if bIsInVoxel and b.z > a.z
 					return b.z
 
 				d = x: b.x - a.x, y: b.y - a.y, z: b.z - a.z

--- a/src/plugins/newBrickator/pipeline/HullVoxelizer.coffee
+++ b/src/plugins/newBrickator/pipeline/HullVoxelizer.coffee
@@ -232,14 +232,6 @@ module.exports = class Voxelizer
 
 				return z
 
-			_normalize: ({x: x, y: y, z: z}) ->
-				length = Math.sqrt x * x + y * y + z * z
-				return {
-					x: x / length
-					y: y / length
-					z: z / length
-				}
-
 			_setVoxel: ({x: x, y: y, z: z}, zValue, direction, grid) ->
 				grid[x] = [] unless grid[x]
 				grid[x][y] = [] unless grid[x][y]

--- a/src/plugins/newBrickator/pipeline/HullVoxelizer.coffee
+++ b/src/plugins/newBrickator/pipeline/HullVoxelizer.coffee
@@ -199,35 +199,35 @@ module.exports = class Voxelizer
 				if bIsInVoxel && b.z > a.z
 					return b.z
 
-				d = @_normalize x: b.x - a.x, y: b.y - a.y, z: b.z - a.z
+				d = x: b.x - a.x, y: b.y - a.y, z: b.z - a.z
 
 				if d.x isnt 0
 					k = (x - 0.5 - a.x) / d.x
-					if k >= 0
+					if k >= 0 and k <= 1
 						return a.z + k * d.z
 
 					k = (x + 0.5 - a.x) / d.x
-					if k >= 0
+					if k >= 0 and k <= 1
 						return a.z + k * d.z
 
 				if d.y isnt 0
 					k = (y - 0.5 - a.y) / d.y
-					if k >= 0
+					if k >= 0 and k <= 1
 						return a.z + k * d.z
 
 					k = (y + 0.5 - a.y) / d.y
-					if k >= 0
+					if k >= 0 and k <= 1
 						return a.z + k * d.z
 
 				if d.z isnt 0
 					minZ = z - 0.5
 					k = (minZ - a.z) / d.z
-					if k >= 0
+					if k >= 0 and k <= 1
 						return minZ
 
 					maxZ = z + 0.5
 					k = (maxZ - a.z) / d.z
-					if k >= 0
+					if k >= 0 and k <= 1
 						return maxZ
 
 				return z

--- a/src/plugins/newBrickator/pipeline/HullVoxelizer.coffee
+++ b/src/plugins/newBrickator/pipeline/HullVoxelizer.coffee
@@ -245,10 +245,8 @@ module.exports = class Voxelizer
 				grid[x][y] = [] unless grid[x][y]
 				oldValue = grid[x][y][z]
 				if oldValue
-					# Overwrite any 0s
-					if oldValue.dir is 0 or
-					# If new z value is higher than the old one and we will not set it to 0
-					(direction isnt 0 and zValue > oldValue.z) or
+					# Update dir if new zValue is higher than the old one
+					if (direction isnt 0 and zValue > oldValue.z) or
 					# Prefer setting direction to 1 (i.e. close the voxel)
 					(direction is 1 and Math.abs(zValue - oldValue.z) < @floatDelta)
 						oldValue.z = zValue

--- a/src/plugins/newBrickator/pipeline/HullVoxelizer.coffee
+++ b/src/plugins/newBrickator/pipeline/HullVoxelizer.coffee
@@ -245,7 +245,11 @@ module.exports = class Voxelizer
 				grid[x][y] = [] unless grid[x][y]
 				oldValue = grid[x][y][z]
 				if oldValue
-					if oldValue.dir is 0 or (direction isnt 0 and zValue > oldValue.z) or
+					# Overwrite any 0s
+					if oldValue.dir is 0 or
+					# If new z value is higher than the old one and we will not set it to 0
+					(direction isnt 0 and zValue > oldValue.z) or
+					# Prefer setting direction to 1 (i.e. close the voxel)
 					(direction is 1 and Math.abs(zValue - oldValue.z) < @floatDelta)
 						oldValue.z = zValue
 						oldValue.dir = direction

--- a/src/plugins/newBrickator/pipeline/VolumeFiller.coffee
+++ b/src/plugins/newBrickator/pipeline/VolumeFiller.coffee
@@ -60,16 +60,14 @@ module.exports = class VolumeFiller
 						# current voxel already exists (shell voxel)
 						dir = grid[x][y][z].dir
 
+						@_setVoxels grid, x, y, currentFillVoxelQueue, 0
+
 						if dir is 1
-							# fill up voxels and leave model
-							@_setVoxels grid, x, y, currentFillVoxelQueue, 0
+							# leaving model
 							insideModel = false
 						else if dir is -1
 							# entering model
-							currentFillVoxelQueue = []
 							insideModel = true
-						else
-							currentFillVoxelQueue = []
 					else
 						# voxel does not exist yet. create if inside model
 						if insideModel
@@ -78,8 +76,8 @@ module.exports = class VolumeFiller
 				return
 
 			_setVoxels: (grid, x, y, zs, voxelData) ->
-				for z in zs
-					@_setVoxel grid, x, y, z, voxelData
+				while zs.length > 0
+					@_setVoxel grid, x, y, zs.pop(), voxelData
 
 			_setVoxel: (grid, x, y, z, voxelData) ->
 				grid[x] ?= []

--- a/src/plugins/newBrickator/pipeline/VolumeFiller.coffee
+++ b/src/plugins/newBrickator/pipeline/VolumeFiller.coffee
@@ -75,9 +75,9 @@ module.exports = class VolumeFiller
 					z++
 				return
 
-			_setVoxels: (grid, x, y, zs, voxelData) ->
-				while zs.length > 0
-					@_setVoxel grid, x, y, zs.pop(), voxelData
+			_setVoxels: (grid, x, y, zValues, voxelData) ->
+				while zValue = zValues.pop()
+					@_setVoxel grid, x, y, zValue, voxelData
 
 			_setVoxel: (grid, x, y, z, voxelData) ->
 				grid[x] ?= []

--- a/src/plugins/newBrickator/pipeline/VolumeFiller.coffee
+++ b/src/plugins/newBrickator/pipeline/VolumeFiller.coffee
@@ -60,16 +60,15 @@ module.exports = class VolumeFiller
 						# current voxel already exists (shell voxel)
 						dir = grid[x][y][z].dir
 
-						@_setVoxels grid, x, y, currentFillVoxelQueue, 0
-
 						if dir is 1
 							# fill up voxels and leave model
+							@_setVoxels grid, x, y, currentFillVoxelQueue, 0
 							insideModel = false
 						else if dir is -1
 							# entering model
+							currentFillVoxelQueue = []
 							insideModel = true
 						else
-							# if not sure fill up
 							currentFillVoxelQueue = []
 					else
 						# voxel does not exist yet. create if inside model


### PR DESCRIPTION
Voxel that had both a negative and a positive normal at the same z level would get filled wrongly if the former was voxelized first. Now the positive normals take precedence over the other ones.