### PR TITLE
Add ExpandBlack to lego shadow to make its outlines thicker

### DIFF
--- a/src/plugins/nodeVisualizer/nodeVisualizer.coffee
+++ b/src/plugins/nodeVisualizer/nodeVisualizer.coffee
@@ -96,7 +96,7 @@ class NodeVisualizer
 
 			@brickShadowSceneTarget = RenderTargetHelper.createRenderTarget(
 				threeRenderer,
-				null,
+				[new ExpandBlackPart(2)],
 				null,
 				@brickShadowOpacity
 			)


### PR DESCRIPTION
Outlines of the lego shadow are displayed thicker (as originally intended)

fixes #522